### PR TITLE
Fix: sort variant sizes numerically in product cards

### DIFF
--- a/src/lib/stock_info.js
+++ b/src/lib/stock_info.js
@@ -97,7 +97,11 @@ export async function getNestedCatalog() {
           color: variant.color,
           precio: precioSinIVA, // Precio del producto aplicado a todas las variantes
           stock_actual: variant.stock_actual || 0
-        }))
+        })).sort((a, b) => {
+          const tallaA = parseFloat(a.talla) || 0;
+          const tallaB = parseFloat(b.talla) || 0;
+          return tallaA - tallaB;
+        })
       };
     });
 


### PR DESCRIPTION
## Summary
- Product variant sizes (tallas) from Supabase had no guaranteed order, causing some product cards to display sizes out of sequence (e.g. 45, 46, 44, 36, 37... instead of 36, 37, 38...)
- Added numeric `.sort()` on variants in `getNestedCatalog()` so all views receive sizes in ascending order
- Fix applied at the data source level (`stock_info.js`) ensuring consistency across the entire app

## Test plan
- [x] All 153 tests passing, no regressions
- [ ] Verify product cards display sizes in ascending order (36 → 46)
- [ ] Check products that previously showed unordered sizes (e.g. Roots Regata Night)