### PR TITLE
Migrate Shopify Admin API auth to OAuth client credentials

### DIFF
--- a/src/lib/shopify-client.js
+++ b/src/lib/shopify-client.js
@@ -1,0 +1,102 @@
+/**
+ * shopify-client.js
+ *
+ * Cliente HTTP compartido para la Admin API de Shopify.
+ * Autenticación vía client credentials grant (OAuth de la Custom App
+ * registrada en el Dev Dashboard). El token se cachea en memoria del
+ * proceso SSR y se renueva automáticamente al expirar.
+ *
+ * Variables de entorno necesarias:
+ *   SHOPIFY_URL           - Dominio de la tienda (ej: 50fc84.myshopify.com)
+ *   SHOPIFY_CLIENT_ID     - Client ID de la app en el Dev Dashboard
+ *   SHOPIFY_CLIENT_SECRET - Client Secret de la app en el Dev Dashboard
+ */
+
+const SHOPIFY_SHOP = import.meta.env.SHOPIFY_URL;
+const SHOPIFY_CLIENT_ID = import.meta.env.SHOPIFY_CLIENT_ID;
+const SHOPIFY_CLIENT_SECRET = import.meta.env.SHOPIFY_CLIENT_SECRET;
+
+export const SHOPIFY_API_VERSION = '2025-04';
+
+let _cachedToken = null;
+let _tokenExpiresAt = 0;
+
+/**
+ * Obtiene un access token válido vía client credentials grant.
+ * Reutiliza el token cacheado si no ha expirado (margen de 60s).
+ * @returns {Promise<string>}
+ */
+export async function getToken() {
+  if (_cachedToken && Date.now() < _tokenExpiresAt - 60_000) {
+    return _cachedToken;
+  }
+
+  const response = await fetch(
+    `https://${SHOPIFY_SHOP}/admin/oauth/access_token`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: SHOPIFY_CLIENT_ID,
+        client_secret: SHOPIFY_CLIENT_SECRET,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Shopify token request failed ${response.status}: ${errorBody}`);
+  }
+
+  const { access_token, expires_in } = await response.json();
+  _cachedToken = access_token;
+  _tokenExpiresAt = Date.now() + expires_in * 1000;
+
+  return _cachedToken;
+}
+
+/**
+ * Devuelve la Response cruda de una petición autenticada a Shopify.
+ * Útil cuando se necesita acceso a headers (ej: `Link` para paginación).
+ * Acepta tanto rutas relativas (`/products.json`) como URLs absolutas
+ * (las que devuelve Shopify en el header `Link` para la página siguiente).
+ *
+ * @param {string} pathOrUrl
+ * @param {RequestInit} [options]
+ * @returns {Promise<Response>}
+ */
+export async function shopifyFetchRaw(pathOrUrl, options = {}) {
+  const token = await getToken();
+  const url = pathOrUrl.startsWith('http')
+    ? pathOrUrl
+    : `https://${SHOPIFY_SHOP}/admin/api/${SHOPIFY_API_VERSION}${pathOrUrl}`;
+
+  return fetch(url, {
+    ...options,
+    headers: {
+      'X-Shopify-Access-Token': token,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+}
+
+/**
+ * Petición autenticada a la Admin API que devuelve el JSON parseado.
+ * Lanza si la respuesta no es 2xx.
+ *
+ * @param {string} path - Ruta relativa (ej: '/customers/search.json')
+ * @param {RequestInit} [options]
+ * @returns {Promise<any>}
+ */
+export async function shopifyFetch(path, options = {}) {
+  const response = await shopifyFetchRaw(path, options);
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Shopify API error ${response.status}: ${errorBody}`);
+  }
+
+  return response.json();
+}

--- a/src/lib/shopify-draft.js
+++ b/src/lib/shopify-draft.js
@@ -1,89 +1,11 @@
 /**
  * shopify-draft.js
  *
- * Servicio para interactuar con la API de Shopify (Dev Dashboard app):
- * - Autenticación via client credentials grant (token expira cada 24h)
- * - Buscar clientes por email
- * - Crear Draft Orders con descuento global
- * - Consultar Draft Orders existentes
- *
- * Variables de entorno necesarias:
- *   SHOPIFY_CLIENT_ID     - Client ID de la app en el Dev Dashboard
- *   SHOPIFY_CLIENT_SECRET - Client Secret de la app en el Dev Dashboard
- *   SHOPIFY_URL           - Dominio de la tienda (ej: 50fc84.myshopify.com)
+ * Operaciones sobre clientes y Draft Orders de Shopify.
+ * La autenticación y el fetch genérico viven en `shopify-client.js`.
  */
 
-const SHOPIFY_SHOP = import.meta.env.SHOPIFY_URL;
-const SHOPIFY_CLIENT_ID = import.meta.env.SHOPIFY_CLIENT_ID;
-const SHOPIFY_CLIENT_SECRET = import.meta.env.SHOPIFY_CLIENT_SECRET;
-const API_VERSION = '2025-04';
-
-// Caché del token en memoria (válido durante la vida del proceso SSR)
-let _cachedToken = null;
-let _tokenExpiresAt = 0;
-
-/**
- * Obtiene un access token válido via client credentials grant.
- * Reutiliza el token cacheado si no ha expirado (con margen de 60s).
- * @returns {Promise<string>} Access token
- */
-async function getToken() {
-  if (_cachedToken && Date.now() < _tokenExpiresAt - 60_000) {
-    return _cachedToken;
-  }
-
-  const response = await fetch(
-    `https://${SHOPIFY_SHOP}/admin/oauth/access_token`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'client_credentials',
-        client_id: SHOPIFY_CLIENT_ID,
-        client_secret: SHOPIFY_CLIENT_SECRET,
-      }),
-    }
-  );
-
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throw new Error(`Shopify token request failed ${response.status}: ${errorBody}`);
-  }
-
-  const { access_token, expires_in } = await response.json();
-  _cachedToken = access_token;
-  _tokenExpiresAt = Date.now() + expires_in * 1000;
-
-  return _cachedToken;
-}
-
-/**
- * Hace una petición autenticada a la API REST de Shopify.
- * Obtiene el token automáticamente (con renovación si ha expirado).
- * @param {string} path - Ruta relativa (ej: '/customers/search.json')
- * @param {Object} options - Opciones de fetch
- * @returns {Promise<Object>} Respuesta JSON de Shopify
- */
-async function shopifyFetch(path, options = {}) {
-  const token = await getToken();
-  const url = `https://${SHOPIFY_SHOP}/admin/api/${API_VERSION}${path}`;
-
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      'X-Shopify-Access-Token': token,
-      'Content-Type': 'application/json',
-      ...options.headers
-    }
-  });
-
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throw new Error(`Shopify API error ${response.status}: ${errorBody}`);
-  }
-
-  return response.json();
-}
+import { shopifyFetch } from './shopify-client.js';
 
 /**
  * Busca un cliente en Shopify por email.

--- a/src/pages/api/admin/sync-product.js
+++ b/src/pages/api/admin/sync-product.js
@@ -1,10 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { shopifyFetch } from '../../../lib/shopify-client.js';
 
 const SUPABASE_URL = import.meta.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
-const SHOPIFY_API_KEY = import.meta.env.SHOPIFY_API_KEY;
 const SHOPIFY_URL = import.meta.env.SHOPIFY_URL;
-const API_VERSION = "2025-04";
 
 /**
  * POST /api/admin/sync-product
@@ -33,25 +32,19 @@ export async function POST({ request, locals }) {
     }
 
     // 1. Obtener producto de Shopify
-    const shopifyUrl = `https://${SHOPIFY_URL}/admin/api/${API_VERSION}/products/${shopify_product_id}.json`;
-    const shopifyResponse = await fetch(shopifyUrl, {
-      headers: {
-        'X-Shopify-Access-Token': SHOPIFY_API_KEY,
-        'Content-Type': 'application/json'
-      }
-    });
-
-    if (!shopifyResponse.ok) {
+    let product;
+    try {
+      const data = await shopifyFetch(`/products/${shopify_product_id}.json`);
+      product = data.product;
+    } catch (err) {
       return new Response(
-        JSON.stringify({ 
-          success: false, 
-          error: `Shopify API error: ${shopifyResponse.status}` 
+        JSON.stringify({
+          success: false,
+          error: err.message
         }),
         { status: 502, headers: { 'Content-Type': 'application/json' } }
       );
     }
-
-    const { product } = await shopifyResponse.json();
 
     // 2. Preparar datos del producto
     let tagsArray = [];

--- a/src/pages/api/cron/sync-shopify.js
+++ b/src/pages/api/cron/sync-shopify.js
@@ -1,11 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
+import { shopifyFetchRaw, SHOPIFY_API_VERSION } from '../../../lib/shopify-client.js';
 
 const SUPABASE_URL = import.meta.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
 const CRON_SECRET = import.meta.env.CRON_SECRET;
-const SHOPIFY_API_KEY = import.meta.env.SHOPIFY_API_KEY;
 const SHOPIFY_URL = import.meta.env.SHOPIFY_URL;
-const API_VERSION = "2025-04";
 
 /**
  * Endpoint de sincronización periódica Shopify → Supabase
@@ -189,15 +188,10 @@ export async function POST({ request }) {
  */
 async function getAllProductsFromShopify() {
   let todosLosProductos = [];
-  let url = `https://${SHOPIFY_URL}/admin/api/${API_VERSION}/products.json?limit=250&status=active`;
+  let url = `https://${SHOPIFY_URL}/admin/api/${SHOPIFY_API_VERSION}/products.json?limit=250&status=active`;
 
   while (url) {
-    const response = await fetch(url, {
-      headers: {
-        'X-Shopify-Access-Token': SHOPIFY_API_KEY,
-        'Content-Type': 'application/json'
-      }
-    });
+    const response = await shopifyFetchRaw(url);
 
     if (!response.ok) {
       throw new Error(`Error en Shopify API: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
## Summary

- Removes the static `SHOPIFY_API_KEY` (Admin API access token) from the codebase. All Shopify Admin API calls now go through OAuth `client_credentials` (Custom App registered in the Shopify Dev Dashboard), using `SHOPIFY_CLIENT_ID` + `SHOPIFY_CLIENT_SECRET`.
- Centralises auth, token caching and request helpers in a new `src/lib/shopify-client.js`. The cron sync, admin single-product sync and Draft Order helpers all consume it.
- Motivation: the Admin API token leaked via Vercel. Migrating to short-lived OAuth tokens (~24 h, auto-renewed) means a future leak no longer requires invalidating credentials at the storefront level — only rotating the Custom App secret.

## Required deploy steps (env)

Before merging this PR, make sure these env vars are present in **Vercel (production + preview)** and your local `.env`:

- `SHOPIFY_URL` — already set
- `SHOPIFY_CLIENT_ID` — Custom App Client ID (Dev Dashboard)
- `SHOPIFY_CLIENT_SECRET` — Custom App Client Secret (Dev Dashboard)

After merge / verification:

- Delete `SHOPIFY_API_KEY` from Vercel and `.env`
- Revoke the leaked Admin API access token from the Shopify Dev Dashboard

The Custom App must have at least the `read_products` scope (used by `cron/sync-shopify` and `admin/sync-product`) plus whatever scopes `shopify-draft.js` already required (customers, draft_orders).

## Test plan

- [x] `pnpm test` passes (153 tests, verified locally)
- [x] `pnpm run build` produces a clean Vercel bundle (verified locally)
- [x] Deploy to preview and trigger `POST /api/cron/sync-shopify` with the `CRON_SECRET` header — products and variants upsert into Supabase
- [x] From `/admin/products`, run a single-product sync — succeeds
- [x] Existing Draft Order flow (`searchCustomerByEmail` / `createDraftOrder`) still works on a real cart checkout