### PR TITLE
Add invoice paid toggle and widen layout to 1600px

### DIFF
--- a/src/components/CartPage.jsx
+++ b/src/components/CartPage.jsx
@@ -196,7 +196,7 @@ const CartPage = ({ DNI, IBAN}) => {
   };
 
   return (
-    <div className="max-w-7xl mx-auto pb-20 lg:pb-0">
+    <div className="max-w-[1600px] mx-auto pb-20 lg:pb-0">
       {/* Banner de modo edición */}
       {isEditingMode && (
         <div className="flex items-center justify-between gap-4 p-4 mb-6 bg-info/5 border border-info/20 rounded-lg">
@@ -287,7 +287,7 @@ const CartPage = ({ DNI, IBAN}) => {
       {/* Bottom bar mobile — visible solo cuando el sidebar no está en pantalla */}
       {cartItems.length > 0 && !sidebarVisible && (
         <div className="fixed bottom-0 left-0 right-0 z-40 lg:hidden bg-base-100 border-t border-base-300 shadow-overlay px-4 py-3">
-          <div className="flex items-center justify-between max-w-7xl mx-auto">
+          <div className="flex items-center justify-between max-w-[1600px] mx-auto">
             <div>
               <p className="text-xs text-roots-earth">{t('invoice.total.total')}</p>
               <p className="text-lg font-bold text-roots-bark tabular-nums">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 ---
 
 <footer class="w-full border-t border-base-300/60 bg-base-200">
-  <div class="max-w-7xl mx-auto flex items-center justify-between px-6 lg:px-10 py-5">
+  <div class="max-w-[1600px] mx-auto flex items-center justify-between px-6 lg:px-10 py-5">
     <a href="/main-view" class="flex items-center gap-3 group">
       <img
         src="/B2B_RootsBarefoot.png"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -64,7 +64,7 @@ export default function Header() {
           : 'h-20 bg-base-100',
       ].join(' ')}
     >
-      <div className="h-full max-w-7xl mx-auto flex items-center justify-between">
+      <div className="h-full max-w-[1600px] mx-auto flex items-center justify-between">
         {/* Brand */}
         <a href={productsUrl} className="flex items-center gap-3 group">
           <div className="flex flex-col">

--- a/src/components/ProductComponents.jsx
+++ b/src/components/ProductComponents.jsx
@@ -258,7 +258,7 @@ export function ProductsByTag({ catalog }) {
   }, [catalog]);
 
   return (
-    <div className="max-w-7xl mx-auto w-full space-y-16">
+    <div className="max-w-[1600px] mx-auto w-full space-y-16">
       {grouped.orderedTags.map(tag => (
         <section key={tag}>
           <div className="flex items-center gap-4 mb-6">

--- a/src/components/admin/AdminInvoices.jsx
+++ b/src/components/admin/AdminInvoices.jsx
@@ -31,7 +31,8 @@ export default function AdminInvoices() {
     date_to: '',
     nif: '',
     company: '',
-    status: ''
+    status: '',
+    is_paid: ''
   });
 
   // Estado de selección (para bulk download)
@@ -64,6 +65,9 @@ export default function AdminInvoices() {
       if (activeFilters.nif) queryParams.append('nif', activeFilters.nif);
       if (activeFilters.company) queryParams.append('company', activeFilters.company);
       if (activeFilters.status) queryParams.append('status', activeFilters.status);
+      if (activeFilters.is_paid !== '' && activeFilters.is_paid !== undefined) {
+        queryParams.append('is_paid', activeFilters.is_paid);
+      }
 
       // Llamar endpoint
       const response = await fetch(`/api/invoices/list?${queryParams}`);
@@ -115,7 +119,8 @@ export default function AdminInvoices() {
       date_to: '',
       nif: '',
       company: '',
-      status: ''
+      status: '',
+      is_paid: ''
     };
     setFilters(clearedFilters);
     // Recargar todas las facturas sin filtros pasándolos como parámetro
@@ -359,6 +364,42 @@ export default function AdminInvoices() {
   };
 
   /**
+   * Marcar/desmarcar factura como pagada (toggle).
+   * Update optimista + rollback en error.
+   */
+  const handleTogglePaid = async (invoiceId, newValue) => {
+    setInvoices(prev => prev.map(inv =>
+      inv.id === invoiceId ? { ...inv, is_paid: newValue } : inv
+    ));
+
+    try {
+      const response = await fetch(`/api/invoices/${invoiceId}/toggle-paid`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_paid: newValue })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        setInvoices(prev => prev.map(inv =>
+          inv.id === invoiceId ? { ...inv, is_paid: !newValue } : inv
+        ));
+        toast.error(data.error || 'Error al actualizar estado de pago');
+        return;
+      }
+
+      toast.success(newValue ? 'Factura marcada como pagada' : 'Factura marcada como pendiente');
+    } catch (error) {
+      console.error('Error toggling paid status:', error);
+      setInvoices(prev => prev.map(inv =>
+        inv.id === invoiceId ? { ...inv, is_paid: !newValue } : inv
+      ));
+      toast.error('Error al actualizar estado de pago');
+    }
+  };
+
+  /**
    * Actualizar número de Shopify
    * Soporta actualizar o eliminar (con string vacío)
    */
@@ -421,6 +462,7 @@ export default function AdminInvoices() {
           onUpdateShopifyNumber={handleUpdateShopifyNumber}
           onCreateDraft={handleCreateDraft}
           creatingDraftId={creatingDraftId}
+          onTogglePaid={handleTogglePaid}
         />
 
         {/* Acciones de bulk */}

--- a/src/components/admin/InvoiceFilters.jsx
+++ b/src/components/admin/InvoiceFilters.jsx
@@ -25,7 +25,8 @@ export default function InvoiceFilters({ filters, onApply, onClear, disabled }) 
       date_to: '',
       nif: '',
       company: '',
-      status: ''
+      status: '',
+      is_paid: ''
     };
     setLocalFilters(clearedFilters);
     onClear();
@@ -109,6 +110,20 @@ export default function InvoiceFilters({ filters, onApply, onClear, disabled }) 
             <option value="cancelled">Cancelada</option>
           </select>
         </div>
+
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-roots-earth">Pago</label>
+          <select
+            value={localFilters.is_paid ?? ''}
+            onChange={(e) => handleInputChange('is_paid', e.target.value)}
+            disabled={disabled}
+            className="select-b2b"
+          >
+            <option value="">Todas</option>
+            <option value="true">Pagadas</option>
+            <option value="false">Pendientes</option>
+          </select>
+        </div>
       </div>
 
       <div className="flex items-center gap-3 mt-5">
@@ -139,7 +154,9 @@ export default function InvoiceFilters({ filters, onApply, onClear, disabled }) 
               localFilters.date_to && `hasta ${localFilters.date_to}`,
               localFilters.nif && `NIF: ${localFilters.nif}`,
               localFilters.company && `Empresa: ${localFilters.company}`,
-              localFilters.status && `Estado: ${localFilters.status}`
+              localFilters.status && `Estado: ${localFilters.status}`,
+              localFilters.is_paid === 'true' && 'Pago: Pagadas',
+              localFilters.is_paid === 'false' && 'Pago: Pendientes'
             ].filter(Boolean).join(' | ')}
           </p>
         </div>

--- a/src/components/admin/InvoiceTable.jsx
+++ b/src/components/admin/InvoiceTable.jsx
@@ -18,7 +18,8 @@ export default function InvoiceTable({
   onDelete,
   onUpdateShopifyNumber,
   onCreateDraft,
-  creatingDraftId
+  creatingDraftId,
+  onTogglePaid
 }) {
   
   const [editingShopifyNumbers, setEditingShopifyNumbers] = useState({});
@@ -85,6 +86,7 @@ export default function InvoiceTable({
                 <th className="px-4 py-3"><div className="skeleton h-3 w-14 rounded bg-base-200" /></th>
                 <th className="px-4 py-3"><div className="skeleton h-3 w-20 rounded bg-base-200" /></th>
                 <th className="px-4 py-3"><div className="skeleton h-3 w-16 rounded bg-base-200" /></th>
+                <th className="px-4 py-3"><div className="skeleton h-3 w-14 rounded bg-base-200" /></th>
                 <th className="px-4 py-3"><div className="skeleton h-3 w-16 rounded bg-base-200" /></th>
               </tr>
             </thead>
@@ -100,6 +102,7 @@ export default function InvoiceTable({
                   <td className="px-4 py-3"><div className="skeleton h-4 w-16 rounded bg-base-200 ml-auto" /></td>
                   <td className="px-4 py-3"><div className="skeleton h-4 w-24 rounded bg-base-200 mx-auto" /></td>
                   <td className="px-4 py-3"><div className="skeleton h-5 w-20 rounded bg-base-200 mx-auto" /></td>
+                  <td className="px-4 py-3"><div className="skeleton h-4 w-4 rounded bg-base-200 mx-auto" /></td>
                   <td className="px-4 py-3"><div className="skeleton h-4 w-24 rounded bg-base-200 mx-auto" /></td>
                 </tr>
               ))}
@@ -141,6 +144,7 @@ export default function InvoiceTable({
               <th className="px-4 py-3 text-right">Total</th>
               <th className="px-4 py-3 text-center">Pedido Shopify</th>
               <th className="px-4 py-3 text-center">Estado</th>
+              <th className="px-4 py-3 text-center">Pagada</th>
               <th className="px-4 py-3 text-center">Acciones</th>
             </tr>
           </thead>
@@ -163,7 +167,7 @@ export default function InvoiceTable({
                   />
                 </td>
 
-                <td className="px-4 py-3 font-semibold text-roots-bark">
+                <td className="px-4 py-3 font-semibold text-roots-bark whitespace-nowrap">
                   {invoice.invoice_number}
                 </td>
 
@@ -209,6 +213,18 @@ export default function InvoiceTable({
                       </span>
                     );
                   })()}
+                </td>
+
+                <td className="px-4 py-3 text-center">
+                  <input
+                    type="checkbox"
+                    checked={!!invoice.is_paid}
+                    onChange={() => onTogglePaid(invoice.id, !invoice.is_paid)}
+                    disabled={loading}
+                    className="checkbox checkbox-sm border-2 border-roots-earth/60 hover:border-roots-bark checked:border-success"
+                    aria-label={invoice.is_paid ? 'Marcar como pendiente' : 'Marcar como pagada'}
+                    title={invoice.is_paid ? 'Pagada' : 'Pendiente de pago'}
+                  />
                 </td>
 
                 <td className="px-4 py-3">

--- a/src/pages/admin/invoices.astro
+++ b/src/pages/admin/invoices.astro
@@ -15,7 +15,7 @@ const title = 'Dashboard - Gestión de Facturas';
 ---
 
 <Layout title={title}>
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+  <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
     <div class="mb-8">
       <h1 class="text-2xl font-bold text-roots-bark tracking-tight">
         Gestión de Facturas

--- a/src/pages/admin/products.astro
+++ b/src/pages/admin/products.astro
@@ -6,7 +6,7 @@ const pageTitle = 'Panel de Productos | Admin';
 ---
 
 <Layout title={pageTitle}>
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+  <div class="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
     <AdminProducts client:load />
   </div>
 </Layout>

--- a/src/pages/api/invoices/[id]/toggle-paid.js
+++ b/src/pages/api/invoices/[id]/toggle-paid.js
@@ -1,0 +1,105 @@
+/**
+ * PATCH /api/invoices/[id]/toggle-paid.js
+ *
+ * Marca una factura como pagada o pendiente (toggle del booleano is_paid)
+ * Solo accesible por administradores
+ *
+ * Body opcional: { is_paid: boolean } para forzar un valor concreto.
+ * Si no se envía body, invierte el valor actual.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.SUPABASE_URL;
+const supabaseServiceKey = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error('Faltan variables de entorno: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY');
+}
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+export const PATCH = async ({ request, params, locals }) => {
+  try {
+    if (!locals?.isAdmin) {
+      return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+        status: 403, headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const { id } = params;
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(id)) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invoice ID inválido' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    let explicitValue = null;
+    try {
+      const body = await request.json();
+      if (typeof body?.is_paid === 'boolean') {
+        explicitValue = body.is_paid;
+      }
+    } catch {
+      // body vacío o inválido — usamos toggle del valor actual
+    }
+
+    const { data: invoice, error: fetchError } = await supabase
+      .from('invoices')
+      .select('id, is_paid')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !invoice) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Factura no encontrada' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const newValue = explicitValue !== null ? explicitValue : !invoice.is_paid;
+
+    const { error: updateError } = await supabase
+      .from('invoices')
+      .update({
+        is_paid: newValue,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', id);
+
+    if (updateError) {
+      console.error('Error toggling paid status:', updateError);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Error al actualizar estado de pago',
+          details: updateError.message
+        }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        invoice_id: id,
+        is_paid: newValue
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Unexpected error in /api/invoices/[id]/toggle-paid:', error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Error interno del servidor',
+        details: error.message
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+};

--- a/src/pages/api/invoices/list.js
+++ b/src/pages/api/invoices/list.js
@@ -10,6 +10,7 @@
  * - nif: NIF/CIF a buscar
  * - company: Nombre de empresa a buscar
  * - status: Estado (pending_review, shopify_draft, completed, cancelled)
+ * - is_paid: Filtrar por estado de pago ('true' | 'false')
  * - page: Número de página (default: 1)
  * - per_page: Resultados por página (default: 50, max: 100)
  */
@@ -42,6 +43,8 @@ export const GET = async ({ request, locals }) => {
     const nif = params.nif?.trim() || null;
     const company = params.company?.trim() || null;
     const status = params.status?.trim() || null;
+    const isPaidParam = params.is_paid?.trim();
+    const isPaid = isPaidParam === 'true' ? true : isPaidParam === 'false' ? false : null;
     const page = Math.max(1, parseInt(params.page) || 1);
     const perPage = Math.min(100, Math.max(10, parseInt(params.per_page) || 50));
 
@@ -94,6 +97,10 @@ export const GET = async ({ request, locals }) => {
       query = query.eq('status', status);
     }
 
+    if (isPaid !== null) {
+      query = query.eq('is_paid', isPaid);
+    }
+
     // Ordenar por fecha descendente (más recientes primero)
     query = query.order('created_at', { ascending: false });
 
@@ -132,7 +139,8 @@ export const GET = async ({ request, locals }) => {
           date_to: params.date_to || null,
           nif: nif,
           company: company,
-          status: status || null
+          status: status || null,
+          is_paid: isPaid
         }
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }


### PR DESCRIPTION
## Summary
- New `is_paid` boolean on invoices with admin checkbox toggle in `/admin/invoices`
- New endpoint `PATCH /api/invoices/[id]/toggle-paid` (admin only) with optimistic UI update + rollback on error
- New filter selector "Pago" (Todas / Pagadas / Pendientes) in `InvoiceFilters` and `is_paid` query param in `GET /api/invoices/list`
- Widen main layout container from `max-w-7xl` (1280px) to `max-w-[1600px]` across: Header, Footer, CartPage, ProductComponents, admin Invoices and admin Products
- Tighten invoice number column with `whitespace-nowrap` and reinforce checkbox border for visibility

## Database migration (already applied in Supabase)
```sql
ALTER TABLE public.invoices
ADD COLUMN is_paid BOOLEAN NOT NULL DEFAULT FALSE;

CREATE INDEX idx_invoices_is_paid ON public.invoices (is_paid);

COMMENT ON COLUMN public.invoices.is_paid IS 'Manually toggled by admin to mark invoice as paid';
```
RLS policies already allow admin UPDATE — no changes needed.

## Test plan
- [x] Open `/admin/invoices` and verify the new "Pagada" column renders with a clearly visible checkbox
- [x] Click the checkbox on a row → row shows toast "Factura marcada como pagada", checkbox stays checked after refresh
- [x] Click again → toast "Factura marcada como pendiente", checkbox unchecked after refresh
- [x] Use the "Pago" filter (Pagadas / Pendientes / Todas) and verify list updates correctly
- [x] Verify invoice number `2026-XXX` no longer wraps to two lines
- [x] Verify Header, Footer, Cart, Products and both admin pages all share the same widened container
- [x] Existing tests: `pnpm test --run` (153/153 passing locally)