### PR TITLE
Add per-variant images with crossfade transition

### DIFF
--- a/src/components/ProductComponents.jsx
+++ b/src/components/ProductComponents.jsx
@@ -4,6 +4,53 @@ import toast from 'react-hot-toast';
 import { useI18n } from '@hooks/useI18n';
 import { useTranslations } from '@i18n/utils';
 
+function VariantImage({ src, alt }) {
+  const [slots, setSlots] = useState({ a: src, b: null, active: 'a' });
+
+  useEffect(() => {
+    if (!src) return;
+    setSlots(prev => {
+      if (prev[prev.active] === src) return prev;
+      const inactive = prev.active === 'a' ? 'b' : 'a';
+      return { ...prev, [inactive]: src, active: inactive };
+    });
+  }, [src]);
+
+  const renderLayer = (layerSrc, isActive) => {
+    if (!layerSrc) return null;
+    const sep = layerSrc.includes('?') ? '&' : '?';
+    return (
+      <img
+        src={`${layerSrc}${sep}width=400`}
+        srcSet={[
+          `${layerSrc}${sep}width=300 300w`,
+          `${layerSrc}${sep}width=400 400w`,
+          `${layerSrc}${sep}width=600 600w`,
+        ].join(', ')}
+        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+        alt={alt}
+        className={[
+          'absolute inset-0 w-full h-full object-cover',
+          'transition-opacity duration-500 ease-out',
+          isActive ? 'opacity-100' : 'opacity-0',
+        ].join(' ')}
+        loading="lazy"
+        width={400}
+        height={400}
+      />
+    );
+  };
+
+  return (
+    <div className="aspect-square bg-base-200/50 overflow-hidden relative group">
+      <div className="absolute inset-0 transition-transform duration-300 ease-out group-hover:scale-105">
+        {renderLayer(slots.a, slots.active === 'a')}
+        {renderLayer(slots.b, slots.active === 'b')}
+      </div>
+    </div>
+  );
+}
+
 export function VariationOption({ variant, isSelected, onSelect, isPreOrder, isReservaB2B }) {
   const isOutOfStock = !isPreOrder && !isReservaB2B && variant.stock_actual <= 0;
   const label = [variant.talla, variant.color].filter(Boolean).join(' / ');
@@ -122,23 +169,11 @@ export function ProductCard({ product }) {
           </div>
         )}
 
-        {product.imagen && (
-          <div className="aspect-square bg-base-200/50 overflow-hidden">
-            <img
-              src={`${product.imagen}${product.imagen.includes('?') ? '&' : '?'}width=400`}
-              srcSet={[
-                `${product.imagen}${product.imagen.includes('?') ? '&' : '?'}width=300 300w`,
-                `${product.imagen}${product.imagen.includes('?') ? '&' : '?'}width=400 400w`,
-                `${product.imagen}${product.imagen.includes('?') ? '&' : '?'}width=600 600w`,
-              ].join(', ')}
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-              alt={product.nombre}
-              className="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
-              loading="lazy"
-              width={400}
-              height={400}
-            />
-          </div>
+        {(selectedVariant?.imagen || product.imagen) && (
+          <VariantImage
+            src={selectedVariant?.imagen || product.imagen}
+            alt={product.nombre}
+          />
         )}
       </div>
 

--- a/src/hooks/useCart.js
+++ b/src/hooks/useCart.js
@@ -100,7 +100,7 @@ export function addToCart({ tag, product, quantity, variant, isPreOrder }) {
   const discount = calculateDiscount(tag, quantity);
   const newItem = {
     id: key,
-    product_img: product.imagen,
+    product_img: variant?.imagen || product.imagen,
     product_id: product.ID_producto,
     name: product.nombre,
     quantity: quantity,

--- a/src/lib/shopify-mappers.js
+++ b/src/lib/shopify-mappers.js
@@ -1,0 +1,8 @@
+export function buildVariantImageMap(product) {
+  return new Map((product?.images || []).map(img => [img.id, img.src]));
+}
+
+export function resolveVariantImage(variant, imageMap) {
+  if (!variant?.image_id) return null;
+  return imageMap.get(variant.image_id) ?? null;
+}

--- a/src/lib/stock_info.js
+++ b/src/lib/stock_info.js
@@ -48,7 +48,8 @@ export async function getNestedCatalog() {
           talla,
           color,
           precio,
-          stock_actual
+          stock_actual,
+          image_url
         )
       `)
       .eq('is_visible', true)
@@ -96,7 +97,8 @@ export async function getNestedCatalog() {
           talla: variant.talla,
           color: variant.color,
           precio: precioSinIVA, // Precio del producto aplicado a todas las variantes
-          stock_actual: variant.stock_actual || 0
+          stock_actual: variant.stock_actual || 0,
+          imagen: variant.image_url || null
         })).sort((a, b) => {
           const tallaA = parseFloat(a.talla) || 0;
           const tallaB = parseFloat(b.talla) || 0;

--- a/src/pages/api/admin/sync-product.js
+++ b/src/pages/api/admin/sync-product.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { shopifyFetch } from '../../../lib/shopify-client.js';
+import { buildVariantImageMap, resolveVariantImage } from '../../../lib/shopify-mappers.js';
 
 const SUPABASE_URL = import.meta.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -87,6 +88,7 @@ export async function POST({ request, locals }) {
     }
 
     // 4. Preparar y upsert variantes
+    const imageMap = buildVariantImageMap(product);
     const variantRows = product.variants.map(variant => {
       let talla = variant.option2;
       let color = variant.option1;
@@ -103,6 +105,7 @@ export async function POST({ request, locals }) {
         color: color || null,
         precio: variant.price ? (parseFloat(variant.price) / 1.21).toFixed(2) : null,
         stock_actual: variant.inventory_quantity || 0,
+        image_url: resolveVariantImage(variant, imageMap),
         last_synced_at: now
       };
     });

--- a/src/pages/api/cron/sync-shopify.js
+++ b/src/pages/api/cron/sync-shopify.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { shopifyFetchRaw, SHOPIFY_API_VERSION } from '../../../lib/shopify-client.js';
+import { buildVariantImageMap, resolveVariantImage } from '../../../lib/shopify-mappers.js';
 
 const SUPABASE_URL = import.meta.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -119,6 +120,8 @@ export async function POST({ request }) {
       const productId = productIdMap[product.id];
       if (!productId) continue;
 
+      const imageMap = buildVariantImageMap(product);
+
       for (const variant of product.variants) {
         let talla = variant.option2;
         let color = variant.option1;
@@ -135,6 +138,7 @@ export async function POST({ request }) {
           color: color || null,
           precio: variant.price ? (parseFloat(variant.price) / 1.21).toFixed(2) : null,
           stock_actual: variant.inventory_quantity || 0,
+          image_url: resolveVariantImage(variant, imageMap),
           last_synced_at: now
         });
       }

--- a/src/test/admin-products.test.js
+++ b/src/test/admin-products.test.js
@@ -57,7 +57,8 @@ const MOCK_SUPABASE_PRODUCTS = [
         talla: '38',
         color: 'Negro',
         precio: '120.00',
-        stock_actual: 5
+        stock_actual: 5,
+        image_url: 'https://cdn.shopify.com/model-a-negro.jpg'
       },
       {
         shopify_variant_id: 90012,
@@ -65,7 +66,8 @@ const MOCK_SUPABASE_PRODUCTS = [
         talla: '40',
         color: 'Negro',
         precio: '120.00',
-        stock_actual: 0
+        stock_actual: 0,
+        image_url: null
       }
     ]
   },
@@ -86,7 +88,8 @@ const MOCK_SUPABASE_PRODUCTS = [
         talla: '35-39',
         color: 'Blanco',
         precio: '15.00',
-        stock_actual: 100
+        stock_actual: 100,
+        image_url: null
       }
     ]
   }
@@ -168,7 +171,8 @@ describe('Shape de datos del catálogo (compatibilidad)', () => {
             talla: variant.talla,
             color: variant.color,
             precio: precioSinIVA,
-            stock_actual: variant.stock_actual || 0
+            stock_actual: variant.stock_actual || 0,
+            imagen: variant.image_url || null
           }))
         };
       });
@@ -253,6 +257,18 @@ describe('Shape de datos del catálogo (compatibilidad)', () => {
     const precios = p1.variants.map(v => v.precio);
     expect(new Set(precios).size).toBe(1);
     expect(precios[0]).toBe('82.64');
+  });
+
+  it('debe exponer variant.imagen cuando image_url existe', () => {
+    const catalog = transformProductsToShape(MOCK_SUPABASE_PRODUCTS);
+    const variantConImagen = catalog[0].variants[0];
+    expect(variantConImagen.imagen).toBe('https://cdn.shopify.com/model-a-negro.jpg');
+  });
+
+  it('variant.imagen debe ser null cuando image_url es null', () => {
+    const catalog = transformProductsToShape(MOCK_SUPABASE_PRODUCTS);
+    const variantSinImagen = catalog[0].variants[1];
+    expect(variantSinImagen.imagen).toBeNull();
   });
 
   it('stock_actual debe ser 0 cuando es null/undefined', () => {

--- a/src/test/unit/shopify-mappers.test.js
+++ b/src/test/unit/shopify-mappers.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { buildVariantImageMap, resolveVariantImage } from '../../lib/shopify-mappers.js';
+
+describe('buildVariantImageMap', () => {
+  it('crea un map id → src desde product.images', () => {
+    const product = {
+      images: [
+        { id: 1, src: 'https://cdn.shopify.com/a.jpg' },
+        { id: 2, src: 'https://cdn.shopify.com/b.jpg' }
+      ]
+    };
+    const map = buildVariantImageMap(product);
+    expect(map.size).toBe(2);
+    expect(map.get(1)).toBe('https://cdn.shopify.com/a.jpg');
+    expect(map.get(2)).toBe('https://cdn.shopify.com/b.jpg');
+  });
+
+  it('devuelve un map vacío cuando product.images es undefined', () => {
+    const map = buildVariantImageMap({});
+    expect(map.size).toBe(0);
+  });
+
+  it('devuelve un map vacío cuando product es null', () => {
+    const map = buildVariantImageMap(null);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('resolveVariantImage', () => {
+  const imageMap = new Map([
+    [1, 'https://cdn.shopify.com/a.jpg'],
+    [2, 'https://cdn.shopify.com/b.jpg']
+  ]);
+
+  it('devuelve la URL cuando image_id matchea', () => {
+    expect(resolveVariantImage({ image_id: 1 }, imageMap)).toBe('https://cdn.shopify.com/a.jpg');
+  });
+
+  it('devuelve null cuando image_id es null', () => {
+    expect(resolveVariantImage({ image_id: null }, imageMap)).toBeNull();
+  });
+
+  it('devuelve null cuando la variante no tiene image_id', () => {
+    expect(resolveVariantImage({}, imageMap)).toBeNull();
+  });
+
+  it('devuelve null cuando image_id no está en el map', () => {
+    expect(resolveVariantImage({ image_id: 999 }, imageMap)).toBeNull();
+  });
+
+  it('devuelve null cuando el map está vacío', () => {
+    expect(resolveVariantImage({ image_id: 1 }, new Map())).toBeNull();
+  });
+});

--- a/src/test/unit/useCart-hooks.test.js
+++ b/src/test/unit/useCart-hooks.test.js
@@ -44,6 +44,53 @@ describe('useCart Hooks - Solución al bug de race condition', () => {
     removeAllFromCart();
   });
 
+  describe('addToCart - imagen de variante', () => {
+    it('usa variant.imagen cuando está definida', () => {
+      act(() => {
+        addToCart({
+          tag: 'CALCETINES',
+          product: mockProduct,
+          quantity: 1,
+          variant: { ...mockVariant, imagen: 'https://cdn.shopify.com/sock-red.jpg' },
+          isPreOrder: false
+        });
+      });
+
+      const items = itemsStore.get();
+      expect(items[0].product_img).toBe('https://cdn.shopify.com/sock-red.jpg');
+    });
+
+    it('cae a product.imagen cuando variant.imagen es null', () => {
+      act(() => {
+        addToCart({
+          tag: 'CALCETINES',
+          product: mockProduct,
+          quantity: 1,
+          variant: { ...mockVariant, imagen: null },
+          isPreOrder: false
+        });
+      });
+
+      const items = itemsStore.get();
+      expect(items[0].product_img).toBe(mockProduct.imagen);
+    });
+
+    it('cae a product.imagen cuando variant.imagen no está definida', () => {
+      act(() => {
+        addToCart({
+          tag: 'CALCETINES',
+          product: mockProduct,
+          quantity: 1,
+          variant: mockVariant, // sin campo imagen
+          isPreOrder: false
+        });
+      });
+
+      const items = itemsStore.get();
+      expect(items[0].product_img).toBe(mockProduct.imagen);
+    });
+  });
+
   describe('useCartItems', () => {
     it('retorna array vacío cuando no hay items', () => {
       const { result } = renderHook(() => useCartItems());


### PR DESCRIPTION
## Summary

- Cada variante puede llevar su propia imagen sincronizada desde Shopify (campo nuevo `product_variants.image_url`).
- `ProductCard` cambia la imagen al seleccionar variante con un crossfade de doble capa (500ms ease-out, solo Tailwind, sin libs externas).
- Carrito guarda la imagen de la variante seleccionada — el thumbnail refleja qué se compró.
- Fallback a `product.imagen` cuando la variante no tiene imagen propia (degradación elegante hasta el siguiente sync).

## Database migration (requerido)

Aplicar en Supabase SQL Editor antes de desplegar:

```sql
ALTER TABLE public.product_variants
  ADD COLUMN IF NOT EXISTS image_url TEXT;
```

Sin la columna, el `select` de `getNestedCatalog()` y los upserts del sync van a fallar.

## Cambios

- `src/lib/shopify-mappers.js` (nuevo) — `buildVariantImageMap` + `resolveVariantImage`, helpers que extraen `product.images[]` y matchean `variant.image_id`.
- `src/pages/api/cron/sync-shopify.js`, `src/pages/api/admin/sync-product.js` — usan los helpers para guardar `image_url` por variante.
- `src/lib/stock_info.js` — `getNestedCatalog` lee `image_url` y expone `variant.imagen`.
- `src/components/ProductComponents.jsx` — nuevo subcomponente `VariantImage` con crossfade de dos capas.
- `src/hooks/useCart.js` — `product_img` usa `variant?.imagen || product.imagen`.
- Tests: 13 nuevos (8 helper + 2 catálogo + 3 cart). Total 166 pasando.

## Test plan

- [x] Aplicar migración SQL en Supabase.
- [x] `pnpm test` — todos los tests pasan.
- [x] Disparar `POST /api/admin/sync-product` con un producto multicolor (calcetines) y verificar en Supabase que `product_variants.image_url` tiene URLs distintas por color.
- [x] `pnpm dev` → ir a `/main-view` → click entre variantes de ese producto → la imagen del card hace crossfade suave.
- [x] Añadir al carrito y comprobar que el thumbnail del item refleja la variante elegida.
- [x] Verificar fallback: producto cuya variante no tiene imagen propia en Shopify debe mostrar `product.imagen` sin imagen rota.
- [x] Esperar al cron horario (o disparar manualmente `/api/admin/sync-shopify`) y validar el flujo en producción.